### PR TITLE
Updating URL for GloVe in setup script

### DIFF
--- a/setup_all.sh
+++ b/setup_all.sh
@@ -2,7 +2,7 @@
 
 # Download pretrained embeddings.
 curl -O http://lsz-gpu-01.cs.washington.edu/resources/glove_50_300_2.txt
-curl -O https://nlp.stanford.edu/data/glove.840B.300d.zip
+curl -O http://downloads.cs.stanford.edu/nlp/data/glove.840B.300d.zip
 unzip glove.840B.300d.zip
 rm glove.840B.300d.zip
 


### PR DESCRIPTION
The old URL returns a redirection page, which curl does not follow.